### PR TITLE
feat: install key + toolchain bump + Nancy CVE suppression

### DIFF
--- a/.github/workflows/check-vulnerabilities.yaml
+++ b/.github/workflows/check-vulnerabilities.yaml
@@ -249,6 +249,7 @@ jobs:
             if go list -json -deps ./... | nancy sleuth \
               --username "$OSS_INDEX_USERNAME" \
               --token "$OSS_INDEX_TOKEN" \
+              --exclude-vulnerability-file .nancy-ignore \
               --output text \
               --loud > nancy-detailed.txt 2>&1; then
 
@@ -308,6 +309,7 @@ jobs:
               go list -json -deps ./... | nancy sleuth \
                 --username "$OSS_INDEX_USERNAME" \
                 --token "$OSS_INDEX_TOKEN" \
+                --exclude-vulnerability-file .nancy-ignore \
                 --output text > nancy-summary.txt 2>&1 || true
             fi
       - name: Generate comprehensive report

--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,0 +1,13 @@
+# Nancy ignore file — documented exceptions for OSS Index findings.
+#
+# Format: one CVE per line. Lines starting with # are comments.
+# Each suppression must have a written justification above it so that
+# future maintainers can re-evaluate when upstream ships a fix.
+
+# CVE-2026-41889 — github.com/jackc/pgx/v5
+# SQL injection, CVSS 2.3 (Low). Indirect dependency pulled in by
+# upper/db. govulncheck reachability analysis confirms no framework
+# code calls the vulnerable symbol. No upstream fix published as of
+# 2026-05-06 (latest pgx/v5 is v5.9.2 — same version Nancy flags).
+# Re-evaluate when jackc/pgx publishes v5.9.3+ or later.
+CVE-2026-41889

--- a/cli/adele/install.go
+++ b/cli/adele/install.go
@@ -11,7 +11,7 @@ import (
 var InstallCommand = &Command{
 	Name:        "install",
 	Help:        "Install a kit into the current project",
-	Description: "Install a packaged kit (such as a frontend pipeline) into the current working directory",
+	Description: "Install a packaged kit (such as a frontend pipeline) or generate a new application key into the current working directory",
 	Usage:       "adele install <kit> [options]",
 	Examples: []string{
 		"adele install starter-kit",
@@ -22,6 +22,8 @@ var InstallCommand = &Command{
 		"adele install starter-kit --vue=2",
 		"adele install starter-kit --with-auth",
 		"adele install starter-kit --vue3 --with-auth",
+		"adele install key",
+		"adele install key --force",
 	},
 	Options: map[string]string{
 		"--skip":        "keep your existing templates; you must wire up the toolchain manually",
@@ -30,6 +32,7 @@ var InstallCommand = &Command{
 		"--vue=N":       "scaffold Vue version N (2 or 3)",
 		"--vue3":        "alias for --vue=3",
 		"--with-auth":   "scaffold a working password-auth flow (vanilla or vue3)",
+		"--force":       "(key only) overwrite an existing KEY value without prompting",
 	},
 }
 
@@ -42,11 +45,13 @@ func NewInstall() *Install {
 func (c *Install) Handle() error {
 	args := Registry.GetArgs()
 	if len(args) < 2 {
-		return fmt.Errorf("missing kit name (available: starter-kit)\nusage: %s", InstallCommand.Usage)
+		return fmt.Errorf("missing kit name (available: starter-kit, key)\nusage: %s", InstallCommand.Usage)
 	}
 
 	kit := args[1]
 	switch kit {
+	case "key":
+		return NewInstallKey(HasOption("--force")).Handle()
 	case "starter-kit":
 		// Resolve flags BEFORE the adele-app gate so an invalid value (e.g.
 		// --vue=4) errors out without first prompting the user to scaffold a
@@ -70,7 +75,7 @@ func (c *Install) Handle() error {
 		// remove?" gate avoids friction on the empty target.
 		return NewStarterKit(variant, skip, withTailwind, justScaffolded, withAuth).Handle()
 	default:
-		return fmt.Errorf("unknown kit %q (available: starter-kit)", kit)
+		return fmt.Errorf("unknown kit %q (available: starter-kit, key)", kit)
 	}
 }
 

--- a/cli/adele/install_key.go
+++ b/cli/adele/install_key.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cidekar/adele-framework/helpers"
+	"github.com/fatih/color"
+)
+
+// keyEnvVar is the name of the env var that holds the application key.
+// Matches the placeholder substitution in templates/env.txt where APP_KEY=${KEY}.
+const keyEnvVar = "APP_KEY"
+
+// keyEnvFile is the env file the command reads/writes, relative to CWD.
+const keyEnvFile = ".env"
+
+// keyLength is the byte length passed to helpers.RandomString. Matches the
+// length used by `adele new` when seeding the initial APP_KEY.
+const keyLength = 32
+
+// InstallKey generates a new application key, writes it into .env (creating or
+// updating the APP_KEY entry), and prints the new key to stdout. Mirrors
+// Laravel's `php artisan key:generate` workflow. Run from the root of an
+// adele application; refuses to write outside one.
+//
+// If APP_KEY already has a non-empty value and --force is not set, the command
+// prompts before overwriting so an accidental run does not invalidate signed
+// session cookies in a live environment.
+type InstallKey struct {
+	Force bool
+}
+
+func NewInstallKey(force bool) *InstallKey {
+	return &InstallKey{Force: force}
+}
+
+func (c *InstallKey) Handle() error {
+	if !IsAdeleApp() {
+		return errors.New("adele install key must be run from the root of an adele application (no go.mod referencing the framework)")
+	}
+
+	envPath := keyEnvFile
+	exists := fileExists(envPath)
+
+	// Prompt before overwriting an existing non-empty key unless --force.
+	if exists && !c.Force {
+		current, err := readEnvValue(envPath, keyEnvVar)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", envPath, err)
+		}
+		if current != "" {
+			confirm, err := confirmOverwriteKey()
+			if err != nil {
+				return err
+			}
+			if !confirm {
+				return errors.New("key install cancelled — existing APP_KEY left unchanged")
+			}
+		}
+	}
+
+	h := helpers.Helpers{}
+	newKey := h.RandomString(keyLength)
+
+	if err := writeEnvValue(envPath, keyEnvVar, newKey); err != nil {
+		return fmt.Errorf("write %s: %w", envPath, err)
+	}
+
+	color.Green("APP_KEY written to %s", envPath)
+	fmt.Println(newKey)
+	return nil
+}
+
+// readEnvValue returns the value of `key` from a dotenv-style file, or the
+// empty string if the key is not present. Lines beginning with '#' are
+// treated as comments. Quoted values have their surrounding quotes stripped
+// to match godotenv's parsing.
+func readEnvValue(path, key string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	prefix := key + "="
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if !strings.HasPrefix(trimmed, prefix) {
+			continue
+		}
+		raw := strings.TrimPrefix(trimmed, prefix)
+		raw = strings.TrimSpace(raw)
+		// Strip a single pair of surrounding quotes if present.
+		if len(raw) >= 2 && (raw[0] == '"' || raw[0] == '\'') && raw[0] == raw[len(raw)-1] {
+			raw = raw[1 : len(raw)-1]
+		}
+		return raw, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", nil
+}
+
+// writeEnvValue sets `key=value` in a dotenv-style file. If the file does not
+// exist it is created. If the key is already present, the existing line is
+// rewritten in place to preserve surrounding lines and comments. If absent,
+// the entry is appended. Writes via a temp file + rename so a partial write
+// can never leave the env in a corrupt state.
+func writeEnvValue(path, key, value string) error {
+	var lines []string
+	found := false
+
+	if fileExists(path) {
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		scanner := bufio.NewScanner(f)
+		prefix := key + "="
+		for scanner.Scan() {
+			line := scanner.Text()
+			trimmed := strings.TrimSpace(line)
+			if !found && strings.HasPrefix(trimmed, prefix) {
+				lines = append(lines, fmt.Sprintf("%s=%s", key, value))
+				found = true
+				continue
+			}
+			lines = append(lines, line)
+		}
+		if err := scanner.Err(); err != nil {
+			f.Close()
+			return err
+		}
+		f.Close()
+	}
+
+	if !found {
+		lines = append(lines, fmt.Sprintf("%s=%s", key, value))
+	}
+
+	// Write atomically: tmp file in the same directory, then rename.
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".env.tmp.*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		// Best-effort cleanup if rename never happened.
+		os.Remove(tmpName)
+	}()
+
+	for _, line := range lines {
+		if _, err := tmp.WriteString(line + "\n"); err != nil {
+			tmp.Close()
+			return err
+		}
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// confirmOverwriteKey reads stdin and returns true only on "yes". Any other
+// answer (or read error) returns false. Prompt phrasing makes the production
+// risk explicit so an operator does not click through habitually.
+func confirmOverwriteKey() (bool, error) {
+	fmt.Println("APP_KEY already has a value in .env.")
+	fmt.Println("Overwriting will invalidate any data signed with the current key")
+	fmt.Println("(session cookies, encrypted columns, signed URLs).")
+	fmt.Print("Type 'yes' to overwrite, anything else to cancel: ")
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	return strings.ToLower(strings.TrimSpace(answer)) == "yes", nil
+}

--- a/cli/adele/install_key_test.go
+++ b/cli/adele/install_key_test.go
@@ -1,0 +1,287 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// seedAdeleApp drops a minimal go.mod into the CWD so IsAdeleApp() reports
+// true. Mirrors the pattern used in install_test.go.
+func seedAdeleApp(t *testing.T) {
+	t.Helper()
+	mod := "module example.com/app\n\nrequire github.com/cidekar/adele-framework v0.0.0\n"
+	if err := os.WriteFile("go.mod", []byte(mod), 0644); err != nil {
+		t.Fatalf("seed go.mod: %v", err)
+	}
+}
+
+func TestInstallKey_FreshEnv_AppendsKey(t *testing.T) {
+	t.Chdir(t.TempDir())
+	seedAdeleApp(t)
+	// No .env file at all — command must create it.
+
+	if err := NewInstallKey(false).Handle(); err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	got, err := os.ReadFile(".env")
+	if err != nil {
+		t.Fatalf("read .env: %v", err)
+	}
+	if !strings.Contains(string(got), "APP_KEY=") {
+		t.Errorf("expected .env to contain APP_KEY=, got: %q", got)
+	}
+}
+
+func TestInstallKey_ExistingEnvWithoutAppKey_AppendsLine(t *testing.T) {
+	t.Chdir(t.TempDir())
+	seedAdeleApp(t)
+	original := "APP_NAME=test\nAPP_DEBUG=true\n"
+	if err := os.WriteFile(".env", []byte(original), 0644); err != nil {
+		t.Fatalf("seed .env: %v", err)
+	}
+
+	if err := NewInstallKey(false).Handle(); err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	got, err := os.ReadFile(".env")
+	if err != nil {
+		t.Fatalf("read .env: %v", err)
+	}
+	s := string(got)
+	if !strings.Contains(s, "APP_NAME=test") {
+		t.Errorf("expected original APP_NAME line preserved, got: %q", s)
+	}
+	if !strings.Contains(s, "APP_DEBUG=true") {
+		t.Errorf("expected original APP_DEBUG line preserved, got: %q", s)
+	}
+	if !strings.Contains(s, "APP_KEY=") {
+		t.Errorf("expected APP_KEY appended, got: %q", s)
+	}
+}
+
+func TestInstallKey_ExistingEmptyAppKey_OverwritesWithoutPrompt(t *testing.T) {
+	t.Chdir(t.TempDir())
+	seedAdeleApp(t)
+	// Empty APP_KEY value should NOT trigger the prompt — it's effectively unset.
+	if err := os.WriteFile(".env", []byte("APP_KEY=\nOTHER=x\n"), 0644); err != nil {
+		t.Fatalf("seed .env: %v", err)
+	}
+
+	if err := NewInstallKey(false).Handle(); err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	got, _ := os.ReadFile(".env")
+	s := string(got)
+	if !strings.Contains(s, "APP_KEY=") || strings.Contains(s, "APP_KEY=\n") {
+		t.Errorf("expected APP_KEY to be set to a non-empty value, got: %q", s)
+	}
+	if !strings.Contains(s, "OTHER=x") {
+		t.Errorf("expected unrelated line preserved, got: %q", s)
+	}
+}
+
+func TestInstallKey_ExistingValue_PromptCancelled(t *testing.T) {
+	t.Chdir(t.TempDir())
+	seedAdeleApp(t)
+	const existing = "DO_NOT_OVERWRITE_ME"
+	if err := os.WriteFile(".env", []byte("APP_KEY="+existing+"\n"), 0644); err != nil {
+		t.Fatalf("seed .env: %v", err)
+	}
+
+	// Pipe "n\n" into stdin — command should cancel without rewriting.
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdin = r
+	_, _ = w.WriteString("n\n")
+	w.Close()
+
+	err = NewInstallKey(false).Handle()
+	if err == nil {
+		t.Fatal("expected error from cancelled prompt, got nil")
+	}
+	if !strings.Contains(err.Error(), "cancelled") {
+		t.Errorf("expected cancellation error, got: %v", err)
+	}
+
+	got, _ := os.ReadFile(".env")
+	if !strings.Contains(string(got), existing) {
+		t.Errorf("expected existing key preserved on cancel, got: %q", got)
+	}
+}
+
+func TestInstallKey_ExistingValue_PromptConfirmed_Overwrites(t *testing.T) {
+	t.Chdir(t.TempDir())
+	seedAdeleApp(t)
+	const existing = "OLD_KEY_VALUE"
+	if err := os.WriteFile(".env", []byte("APP_KEY="+existing+"\n"), 0644); err != nil {
+		t.Fatalf("seed .env: %v", err)
+	}
+
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdin = r
+	_, _ = w.WriteString("yes\n")
+	w.Close()
+
+	if err := NewInstallKey(false).Handle(); err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	got, _ := os.ReadFile(".env")
+	if strings.Contains(string(got), existing) {
+		t.Errorf("expected old key replaced, but %q still present in: %q", existing, got)
+	}
+	if !strings.Contains(string(got), "APP_KEY=") {
+		t.Errorf("expected new APP_KEY in: %q", got)
+	}
+}
+
+func TestInstallKey_Force_OverwritesWithoutPrompt(t *testing.T) {
+	t.Chdir(t.TempDir())
+	seedAdeleApp(t)
+	const existing = "WILL_BE_REPLACED"
+	if err := os.WriteFile(".env", []byte("APP_KEY="+existing+"\n"), 0644); err != nil {
+		t.Fatalf("seed .env: %v", err)
+	}
+
+	// No stdin pipe — if --force prompts, the test will hang. The fact that
+	// it does not hang is part of the assertion.
+	if err := NewInstallKey(true).Handle(); err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	got, _ := os.ReadFile(".env")
+	if strings.Contains(string(got), existing) {
+		t.Errorf("expected --force to replace existing key, but %q still present in: %q", existing, got)
+	}
+}
+
+func TestInstallKey_NotInAdeleApp_Errors(t *testing.T) {
+	t.Chdir(t.TempDir())
+	// Deliberately do NOT seed go.mod — IsAdeleApp() should return false.
+
+	err := NewInstallKey(false).Handle()
+	if err == nil {
+		t.Fatal("expected error when not in an adele app, got nil")
+	}
+	if !strings.Contains(err.Error(), "adele application") {
+		t.Errorf("expected error to mention 'adele application', got: %v", err)
+	}
+
+	if _, err := os.Stat(".env"); !os.IsNotExist(err) {
+		t.Errorf("expected no .env to be created when not in an adele app, got Stat err: %v", err)
+	}
+}
+
+func TestInstallKey_KeyHasExpectedShape(t *testing.T) {
+	t.Chdir(t.TempDir())
+	seedAdeleApp(t)
+
+	if err := NewInstallKey(false).Handle(); err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	got, _ := os.ReadFile(".env")
+	lines := strings.Split(strings.TrimSpace(string(got)), "\n")
+	var key string
+	for _, line := range lines {
+		if strings.HasPrefix(line, "APP_KEY=") {
+			key = strings.TrimPrefix(line, "APP_KEY=")
+			break
+		}
+	}
+	if key == "" {
+		t.Fatalf("APP_KEY missing or empty in .env: %q", got)
+	}
+	if len(key) != keyLength {
+		t.Errorf("expected key length %d, got %d (%q)", keyLength, len(key), key)
+	}
+}
+
+func TestInstallKey_TwoRunsProduceDifferentKeys(t *testing.T) {
+	t.Chdir(t.TempDir())
+	seedAdeleApp(t)
+
+	if err := NewInstallKey(false).Handle(); err != nil {
+		t.Fatalf("first Handle(): %v", err)
+	}
+	first, _ := readEnvValue(".env", "APP_KEY")
+
+	if err := NewInstallKey(true).Handle(); err != nil {
+		t.Fatalf("second Handle(): %v", err)
+	}
+	second, _ := readEnvValue(".env", "APP_KEY")
+
+	if first == "" || second == "" {
+		t.Fatalf("expected both keys to be non-empty (first=%q second=%q)", first, second)
+	}
+	if first == second {
+		t.Errorf("expected two separate runs to produce different keys, both were %q", first)
+	}
+}
+
+func TestInstallKey_PreservesCommentsAndOrder(t *testing.T) {
+	t.Chdir(t.TempDir())
+	seedAdeleApp(t)
+	original := "# managed env\nAPP_NAME=test\n\n# auth\nAPP_KEY=OLD\nDB_HOST=localhost\n"
+	if err := os.WriteFile(".env", []byte(original), 0644); err != nil {
+		t.Fatalf("seed .env: %v", err)
+	}
+
+	if err := NewInstallKey(true).Handle(); err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	got, _ := os.ReadFile(".env")
+	s := string(got)
+	if !strings.Contains(s, "# managed env") {
+		t.Errorf("expected leading comment preserved: %q", s)
+	}
+	if !strings.Contains(s, "# auth") {
+		t.Errorf("expected inline comment preserved: %q", s)
+	}
+	if !strings.Contains(s, "DB_HOST=localhost") {
+		t.Errorf("expected trailing line preserved: %q", s)
+	}
+	// APP_KEY should remain in its original position (4th non-blank line).
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	var keyIdx = -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, "APP_KEY=") {
+			keyIdx = i
+			break
+		}
+	}
+	if keyIdx == -1 {
+		t.Fatalf("APP_KEY missing: %q", s)
+	}
+	if keyIdx != 4 {
+		t.Errorf("expected APP_KEY rewritten at index 4 (its original slot), got index %d in %v", keyIdx, lines)
+	}
+}
+
+func TestInstallCommand_KeyExampleListed(t *testing.T) {
+	// Sanity check that the help text advertises the `key` subcommand.
+	var found bool
+	for _, ex := range InstallCommand.Examples {
+		if strings.Contains(ex, "adele install key") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected `adele install key` in InstallCommand.Examples, got %v", InstallCommand.Examples)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/cidekar/adele-framework
 
 go 1.25.0
 
+toolchain go1.25.9
+
 replace google.golang.org/genproto => google.golang.org/genproto/googleapis/api v0.0.0-20250818200422-3122310a409c
 
 require (


### PR DESCRIPTION
## Summary

  Bundles three small, independently-reviewable concerns that all need to ship before the next release:

  1. **`adele install key`** — new CLI subcommand that generates / regenerates `APP_KEY` in `.env` for an existing project. Filled the gap where `adele new`
  produces a key once but there was no path to rotate it without hand-editing.
  2. **Go toolchain pinned to `go1.25.9`** — `go.mod` now carries a `toolchain` directive alongside the existing `go 1.25.0` language version. Auto-fetches
  the patched stdlib on every build/CI run; no source changes required.
  3. **Nancy security gate: documented suppression for pgx CVE-2026-41889** — wires `--exclude-vulnerability-file .nancy-ignore` into both `nancy sleuth`
  invocations in the workflow, plus a new `.nancy-ignore` documenting the suppression rationale.

  ## Why each piece

  ### Install key

  - `adele new` scaffolds an `APP_KEY` once. Rotating the key (post-leak, periodic rotation, key derivation change) had no first-class path — users were
  hand-editing `.env`.
  - New shape: `adele install key` (interactive overwrite prompt) and `adele install key --force` (non-interactive, for CI/automation).
  - Same `Install` dispatch surface as `adele install starter-kit`, so help text and registry stay coherent.

  ### Toolchain bump

  - `govulncheck ./...` against the previous `go1.25.0` base reported **21 reachable stdlib CVEs** in framework code paths — TLS handshake, x509 verification,
   html/template render, net/url query parsing, os Root escape, etc.
  - All 21 are fixed in 1.25.x patch releases (latest fix: `go1.25.9`).
  - Bumping the `toolchain` directive (not the `go` directive) is API-safe — patch releases within a minor series are bug/security fixes only. No language
  version change, no source edits.
  - Post-bump verification: `go build`, `go vet`, full test suite (23 packages), and `govulncheck` all clean.

  ### Nancy CVE suppression

  - Nancy's most recent run flagged `CVE-2026-41889` (pgx/v5 SQL injection, **CVSS 2.3 Low**) and failed CI.
  - pgx is an indirect dependency pulled in by `upper/db`; framework code does not call the vulnerable symbol — `govulncheck`'s reachability analysis confirms
   zero call sites.
  - No upstream fix is published as of 2026-05-06. We are already pinned to the latest released `pgx/v5 v5.9.2`, the same version Nancy flags.
  - Rather than block CI on a noise finding with no actionable remediation, we add a documented suppression in `.nancy-ignore` with an explicit re-evaluation
  trigger (`jackc/pgx v5.9.3+`).
  - The workflow's `Recommended Actions` block (line 384) already documented `.nancy-ignore` as the supported escape hatch — this PR just plugs in the wiring.
