### PR TITLE
feat: MX/DNS deliverability check for email validation (IsEmailMX)

### DIFF
--- a/helpers/validators.go
+++ b/helpers/validators.go
@@ -2,11 +2,13 @@ package helpers
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -585,4 +587,59 @@ func isSubsetOf(have map[int]struct{}, want []int) bool {
 		}
 	}
 	return true
+}
+
+// IsEmailMX checks that the email's domain is actually able to receive mail.
+// It mirrors PHP egulias/email-validator's DNSCheckValidation, the check
+// behind the email:mx and email:dns rules. The name says "MX", but per
+// RFC 5321 §5 a domain can accept mail through an MX record or, failing that,
+// a plain A/AAAA address record — so we accept either. A domain publishing an
+// RFC 7505 null MX (a single "." target) has explicitly opted out of email
+// and is rejected.
+//
+// This is the only validator here that does live DNS work, so it takes a
+// context and leaves timeout, cancellation, and deadline to the caller. Any
+// resolver failure (SERVFAIL, timeout, and so on) counts as a fail, matching
+// egulias' fail-closed behavior.
+//
+// Like IsEmailScriptSafe, it returns true/false and records an error via
+// AddError on failure so callers collect errors the same way everywhere.
+//
+// Example:
+//
+//	email := r.Form.Get("email")
+//	validator.IsEmailMX(r.Context(), "email", email)
+func (v *Validation) IsEmailMX(ctx context.Context, field, value string) bool {
+	at := strings.LastIndex(value, "@")
+	if at < 0 || at == len(value)-1 {
+		v.AddError(field, "Invalid email address")
+		return false
+	}
+	domain := strings.TrimSuffix(value[at+1:], ".")
+	if domain == "" {
+		v.AddError(field, "Invalid email address")
+		return false
+	}
+
+	var r net.Resolver
+
+	// Prefer MX records, same as egulias.
+	if mx, err := r.LookupMX(ctx, domain); err == nil && len(mx) > 0 {
+		// A lone "." (or empty) host is an RFC 7505 null MX: the domain has
+		// said it accepts no mail, so treat it as invalid.
+		if len(mx) == 1 && (mx[0].Host == "" || mx[0].Host == ".") {
+			v.AddError(field, "Email domain does not accept mail")
+			return false
+		}
+		return true
+	}
+
+	// No MX? Fall back to A/AAAA. RFC 5321 §5.1 makes a domain with only an
+	// address record an implicit mail exchanger, and egulias honors that.
+	if hosts, err := r.LookupHost(ctx, domain); err == nil && len(hosts) > 0 {
+		return true
+	}
+
+	v.AddError(field, "Email domain has no mail exchanger")
+	return false
 }

--- a/helpers/validators_test.go
+++ b/helpers/validators_test.go
@@ -1,11 +1,14 @@
 package helpers
 
 import (
+	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 func createValidation() *Validation {
@@ -489,6 +492,106 @@ func TestIsEmailScriptSafe(t *testing.T) {
 			got := v.IsEmailScriptSafe("email", tc.email)
 			if got != tc.want {
 				t.Fatalf("IsEmailScriptSafe(%q) = %v, want %v (errors=%v)",
+					tc.email, got, tc.want, v.Errors)
+			}
+			if tc.want && len(v.Errors) != 0 {
+				t.Fatalf("expected no error on pass, got %v", v.Errors)
+			}
+			if !tc.want {
+				if _, ok := v.Errors["email"]; !ok {
+					t.Fatalf("expected error on fail, got none")
+				}
+			}
+		})
+	}
+}
+
+// ----------------------------------------------------------------------------
+// IsEmailMX — matches PHP egulias/email-validator DNSCheckValidation (the
+// email:mx / email:dns rule).
+//
+// The malformed-input cases below never touch the network. The DNS cases are
+// gated behind a short-timeout context and skip themselves when there's no
+// resolver available, so the suite stays green offline and in CI sandboxes.
+// ----------------------------------------------------------------------------
+
+func TestIsEmailMX_MalformedInput(t *testing.T) {
+	// These fail on parsing alone and must never hit DNS, so a cancelled
+	// context is safe — if any of them tried to resolve, it would error out
+	// the same way, but the point is they short-circuit before the lookup.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cases := []struct {
+		name  string
+		email string
+	}{
+		{"no_at_sign", "not-an-email"},
+		{"trailing_at", "user@"},
+		{"empty_string", ""},
+		{"domain_is_bare_dot", "user@."},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := createValidation()
+			if got := v.IsEmailMX(ctx, "email", tc.email); got {
+				t.Fatalf("IsEmailMX(%q) = true, want false", tc.email)
+			}
+			if _, ok := v.Errors["email"]; !ok {
+				t.Fatalf("expected error on fail, got none")
+			}
+		})
+	}
+}
+
+// hasResolver reports whether outbound DNS actually works in this environment.
+// Used to skip the live-lookup cases rather than fail them offline.
+func hasResolver(t *testing.T) bool {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var r net.Resolver
+	if _, err := r.LookupHost(ctx, "google.com"); err != nil {
+		return false
+	}
+	return true
+}
+
+func TestIsEmailMX_LiveLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live DNS lookups in -short mode")
+	}
+	if !hasResolver(t) {
+		t.Skip("no DNS resolver available; skipping live MX checks")
+	}
+
+	cases := []struct {
+		name  string
+		email string
+		want  bool // true = domain can receive mail
+	}{
+		// gmail.com has real MX records.
+		{"has_mx", "someone@gmail.com", true},
+		// github.io serves web content with A records but publishes no MX,
+		// so it's accepted via the RFC 5321 §5.1 address-record fallback.
+		{"a_record_fallback", "someone@github.io", true},
+		// example.com publishes an RFC 7505 null MX ("0 ."), explicitly opting
+		// out of mail, so it must be rejected even though it has A records.
+		{"null_mx_rejected", "someone@example.com", false},
+		// A domain that resolves nowhere at all.
+		{"nonexistent_domain", "someone@this-domain-does-not-exist-xyz-9f8a.invalid", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			v := createValidation()
+			got := v.IsEmailMX(ctx, "email", tc.email)
+			if got != tc.want {
+				t.Fatalf("IsEmailMX(%q) = %v, want %v (errors=%v)",
 					tc.email, got, tc.want, v.Errors)
 			}
 			if tc.want && len(v.Errors) != 0 {


### PR DESCRIPTION
# 📬 feat: Email domain deliverability validation (`IsEmailMX`)

## 📋 Summary
Adds `IsEmailMX` to the `helpers` validation suite — a live DNS check that verifies an email address's domain can actually receive mail. This closes the gap between *syntactic* email validation (`IsEmail`, `IsEmailScriptSafe`) and *deliverability*: an address can be perfectly well-formed and still point at a domain that accepts no mail.

## ✨ What's New

### 🔍 `(*Validation) IsEmailMX(ctx, field, value) bool`
- Accepts a domain that publishes an **MX**, **or** (per RFC 5321 §5.1) a bare **A/AAAA** address record — a domain with only an address record is an   implicit mail exchanger, and egulias honors this.
- Rejects the **RFC 7505 null MX** (`0 .`) — a domain that has explicitly opted out of mail, even if it still has A records.
- **Context-aware**: the only validator in the package that performs live DNS I/O, so it takes a `context.Context` — the caller owns timeout, cancellation, and deadline.
- **Fail-closed**: any resolver error (SERVFAIL, timeout, etc.) is treated as invalid, matching egulias' default.
- Returns `true`/`false` and records an error via `AddError` on failure — mirrors `IsEmailScriptSafe` so callers accumulate errors uniformly.

## 💡 Why
- `IsEmail` proves an address is *well-formed*; it says nothing about whether the domain can receive mail. Signup flows, contact forms, and lead capture all want the stronger guarantee.
- Keeping the semantics identical to `egulias/email-validator` means the Go and PHP stacks reject the same addresses — no cross-stack surprises.

## 📝 Changes

### `helpers/validators.go`
- ➕ Added `IsEmailMX` with full GoDoc + usage example.
- 📦 Added `context` and `net` imports.

### `helpers/validators_test.go`
- ✅ `TestIsEmailMX_MalformedInput` — hermetic, never touches DNS
  (missing `@`, trailing `@`, empty, bare-dot domain); run under a cancelled
  context to prove they short-circuit before any lookup.
- ✅ `TestIsEmailMX_LiveLookup` — real DNS cases, **skipped** on `-short` or when
- ✅ `TestIsEmailMX_MalformedInput` — hermetic, never touches DNS
  (missing `@`, trailing `@`, empty, bare-dot domain); run under a cancelled
  context to prove they short-circuit before any lookup.
- ✅ `TestIsEmailMX_LiveLookup` — real DNS cases, **skipped** on `-short` or when
  no resolver is reachable, so the suite stays green offline / in CI sandboxes:
  - `gmail.com` → has MX (pass)
  - `github.io` → A record, no MX → RFC 5321 §5.1 fallback (pass)
  - `example.com` → RFC 7505 null MX `0 .` → rejected
  - `.invalid` domain → resolves nowhere (fail)

## 💻 Example Usage
```go
email := r.Form.Get("email")
v := h.NewValidator(r.Form)
v.IsEmail("email", email)                 // syntax
v.IsEmailScriptSafe("email", email)       // homograph / spoof
v.IsEmailMX(r.Context(), "email", email)  // deliverability
if !v.Valid() { /* ... */ }
```

✅ Verification

- go build ./helpers/ ✓
- go vet ./helpers/ ✓
- go test ./helpers/ ✓ (full suite)
- go test ./helpers/ -short ✓ (live DNS cases skip cleanly)

🔒 Backward Compatibility

Purely additive — new method, no changes to existing signatures or behavior.